### PR TITLE
build(jorel): use nixpkgs-unstable for home-manager

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -160,11 +160,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1661450036,
-        "narHash": "sha256-0/9UyJLtfWqF4uvOrjFIzk8ue1YYUHa6JIhV0mALkH0=",
+        "lastModified": 1661628722,
+        "narHash": "sha256-oR/7NhG7pPkACToUtaaT6hH+rONE2z5/4NzjoUwEZt8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f3d0897be466aa09a37f6bf59e62c360c3f9a6cc",
+        "rev": "324c8aaf25b2f2027af7798e5582ce3040a793b6",
         "type": "github"
       },
       "original": {
@@ -175,11 +175,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1661427965,
-        "narHash": "sha256-LJeSDbiebN0/eRt9vyOm+Bxljdsq5ZdalmmTk9Xpp30=",
+        "lastModified": 1661700591,
+        "narHash": "sha256-NZa+z+TJC+Hk+87+LKkjFFmBn4GyMVEPcWFXFU+aTkU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "058de3818577db19d1965c21e2479916a3eaaf95",
+        "rev": "16236dd7e33ba4579ccd3ca8349396b2f9c960fe",
         "type": "github"
       },
       "original": {
@@ -255,7 +255,7 @@
       },
       "locked": {
         "lastModified": 1,
-        "narHash": "sha256-6zdGWTd91IysAcAx/zba5qUxgl8MaUjvHF2hdW9ug1c=",
+        "narHash": "sha256-lZOATQRNibY5gg3KdYKzQ/3pT7n5RmPiCPmMocdRdG0=",
         "path": "./bin",
         "type": "path"
       },

--- a/flake.nix
+++ b/flake.nix
@@ -120,7 +120,7 @@
         };
       };
       homeConfigurations = {
-        jorel = mkHomeManager (mkPkgs nixpkgs { allowUnfree = true; })
+        jorel = mkHomeManager (mkPkgs nixpkgs-unstable { allowUnfree = true; })
           home-manager "jorel";
         klong =
           mkHomeManager (mkPkgs nixpkgs-unstable { allowUnfree = true; }) home-manager

--- a/modules/home/programs/nodejs/default.nix
+++ b/modules/home/programs/nodejs/default.nix
@@ -6,14 +6,11 @@ in {
   options.modules.nodejs = { enable = mkEnableOption "nodejs"; };
   config = mkIf cfg.enable {
     home.packages = with pkgs; [
-      nodejs
-      node2nix
-      yarn2nix
-      nodePackages.npm
+      nodejs-16_x
+      yarn
       nodePackages.node-gyp
       nodePackages.node-pre-gyp
       nodePackages.node-gyp-build
-      yarn
     ];
   };
 }


### PR DESCRIPTION
- build: use nixpkgs-unstable for jorel
- fix: use node v16
