### PR TITLE
feat(sxhkd): add shortcut to print current window with maim (DOT-71)

### DIFF
--- a/modules/home/programs/sxhkd/default.nix
+++ b/modules/home/programs/sxhkd/default.nix
@@ -42,6 +42,8 @@ in {
             dunstctl close
         ''}
 
+        super + p
+          maim -i $(xdotool getactivewindow) | xclip -selection clipboard -t image/png
         super + Escape
           pkill -USR1 -x sxhkd
         super + alt + {q,r}


### PR DESCRIPTION
### Summary

- [X] Screenshot the active window and save it to the clipboard for quick past‐ing.
 `maim -i $(xdotool getactivewindow) | xclip -selection clipboard -t image/png`
