### PR TITLE
feat: add fd, sd and duf to default hm packages

### DIFF
--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -18,6 +18,7 @@
     rofi
     tig
     s-tui
+    duf
     python3
     zathura
     maim
@@ -25,6 +26,8 @@
     yank
     jq
     yq
+    sd
+    fd
     cachix
   ];
   programs = { home-manager = { enable = true; }; };


### PR DESCRIPTION
### Summary

This PR adds `sd` and `fd` to default `home-manager` packages.

This will be handy to cases where we want to replace multiple instances across a project.

E.g.
``` bash
sd 'from "react"' 'from "preact"' $(fd --type file)
```

This will replace `from "react"` to `from "preact"` in all ocurrences in the current directory