### PR TITLE
fix: define treesitter parser install dir (DOT-79)

### DIFF
--- a/config/neovim/init.lua
+++ b/config/neovim/init.lua
@@ -2,7 +2,12 @@ require("onedarkpro").setup({
 	theme = "onedark_dark",
 })
 
+-- Defines a rw for treesitter in the cache dir
+local parser_install_dir = vim.fn.stdpath("cache") .. "/treesitters"
+vim.fn.mkdir(parser_install_dir, "p")
+
 require("nvim-treesitter.configs").setup({
+	parser_install_dir = parser_install_dir,
 	ensure_installed = {
 		"bash",
 		"typescript",


### PR DESCRIPTION
### Summary

Fix `treesitter` complaining about non read-write folder to install parser