### PR TITLE
feat: Add gcloud configuration and package to home profile and default.nix

### DIFF
--- a/modules/programs/default.nix
+++ b/modules/programs/default.nix
@@ -14,6 +14,7 @@
     ./neovim
     ./alacritty
     ./gcalcli
+    ./gcloud
     ./gptcommit
     ./jrnl
     ./sxhkd

--- a/modules/programs/gcloud/default.nix
+++ b/modules/programs/gcloud/default.nix
@@ -1,0 +1,14 @@
+{ pkgs, lib, config, ... }:
+
+with lib;
+let cfg = config.modules.gcloud;
+in {
+  options.modules.gcloud = { enable = mkEnableOption "gcloud"; };
+  config = mkIf cfg.enable {
+    home.packages = with pkgs;
+      [
+        (google-cloud-sdk.withExtraComponents
+          [ google-cloud-sdk.components.gke-gcloud-auth-plugin ])
+      ];
+  };
+}

--- a/profiles/jorel/home.nix
+++ b/profiles/jorel/home.nix
@@ -41,7 +41,6 @@
       chromium
       openconnect
       openshift
-      google-cloud-sdk
       k9s
       kubectl
       kubernetes-helm
@@ -256,6 +255,7 @@
     neovim.enable = true;
     gcalcli.enable = true;
     gptcommit.enable = false;
+    gcloud.enable = true;
     timewarrior.enable = true;
     dockerTools.enable = true;
     jrnl = {


### PR DESCRIPTION
- Add configuration for gcloud via `default.nix` file
- Include `gcloud` package in `profiles/jorel/home.nix`
- Import `./gcloud` module in `modules/programs/default.nix`
