### PR TITLE
refactor: improve weechat module with default scripts

### DIFF
--- a/modules/programs/weechat/default.nix
+++ b/modules/programs/weechat/default.nix
@@ -4,12 +4,18 @@ with lib;
 let
   cfg = config.modules.weechat;
   scripts = cfg.scripts;
+  defaultScripts = with pkgs.weechatScripts; [
+    weechat-autosort
+    weechat-go
+    url_hint
+    edit
+  ];
 in {
   options.modules.weechat = {
     enable = mkEnableOption "weechat";
-    scripts = mkOption {
+    additionalScripts = mkOption {
       type = types.listOf types.package;
-      default = with pkgs.weechatScripts; [ weechat-autosort url_hint edit ];
+      default = [ ];
       description = "List of weechat scripts to install.";
     };
   };
@@ -23,7 +29,7 @@ in {
               perl
               (python.withPackages (p: with p; [ websocket-client ]))
             ];
-            scripts = cfg.scripts;
+            scripts = cfg.additionalScripts ++ defaultScripts;
             init = ''
               /set irc.look.server_buffer independent
 

--- a/profiles/jorel/home.nix
+++ b/profiles/jorel/home.nix
@@ -259,12 +259,7 @@
     wally.enable = true;
     weechat = {
       enable = true;
-      scripts = with pkgs.weechatScripts; [
-        wee-slack
-        url_hint
-        weechat-autosort
-        weechat-go
-      ];
+      additionalScripts = with pkgs.weechatScripts; [ wee-slack ];
     };
     xournalpp.enable = true;
     zsh.enable = true;

--- a/profiles/klong/home.nix
+++ b/profiles/klong/home.nix
@@ -189,12 +189,7 @@
     qutebrowser.enable = true;
     weechat = {
       enable = true;
-      scripts = with pkgs.weechatScripts; [
-        wee-slack
-        url_hint
-        weechat-autosort
-        weechat-go
-      ];
+      additionalScripts = with pkgs.weechatScripts; [ wee-slack ];
     };
     xournalpp.enable = true;
     zsh.enable = true;


### PR DESCRIPTION
- Modified `home.nix` for user profiles `jorel` and `klong`, updating configuration files and altering Weechat scripts.
- Renamed 'scripts` to `additionalScripts` in Weechat module configuration within `modules/programs/weechat/default.nix` and introduced `defaultScripts` set.
- Included utility updates and additions in `modules` section for 'jorel' profile.
- Ensured updated scripts are treated as supplementary to `defaultScripts` in Weechat module.
